### PR TITLE
Remove the LaTeX output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # uat-chooser
 
 A widget for choosing concepts from the
-[Unified Astronomy Thesaurus](http://astrothesaurus.org/). It currently looks
-like this:
+[Unified Astronomy Thesaurus](http://astrothesaurus.org/) (UAT). It currently
+looks like this:
 
 ![Simple example screenshot](img/screenshot.png)
+
+We host a live version of the widget on the UAT website:
+
+http://astrothesaurus.org/concept-select/
 
 The original code was donated by [eJournalPress](https://ejpress.com/). This
 module is maintained by the [American Astronomical Society](https://aas.org/).
@@ -27,6 +31,17 @@ $ npm run build
 and then copy the contents of the `dist/` directory, minus `index.html`, to
 your web server. Tweak the sample HTML and embed it in your webpage as
 appropriate.
+
+To test the local code in a web browser, you can launch a webserver that
+serves static files from the `dist/` directory. There are
+[many ways to do this](https://gist.github.com/willurd/5720255). We suggest:
+
+```
+$ cd dist
+$ npx httpserver 8000
+```
+
+Then navigate your browser to <http://localhost:8000/>.
 
 **TODO**: show how to extract the list of selected keywords!
 

--- a/src/ejp_uat.js
+++ b/src/ejp_uat.js
@@ -130,10 +130,6 @@ Uat.Autocompleter = Class.create(Autocompleter.Base,
             // Initialize links to display
             this.options.links = [];
             var link = {};
-            link['action'] = 'latex_popup';
-            link['label'] = 'Cut/Paste Latex';
-            this.options.links.push( link );
-            link = {};
             link['action'] = 'text_popup';
             link['label'] = 'Cut/Paste Text';
             this.options.links.push( link );
@@ -353,12 +349,11 @@ Uat.Autocompleter = Class.create(Autocompleter.Base,
         var action = linkElement.getAttribute('action');
         if ( action == 'text_popup' ) {
             this.getClipboardPopup( this.getTextTerms(), 'text' );
-        } else if ( action == 'latex_popup' ) {
-            this.getClipboardPopup( this.getLatexTerms(), 'latex' );
         }
 
         return;
     },
+
     getTextTerms: function() {
         var terms = this.getAddedTerms();
         var html = '';
@@ -372,20 +367,7 @@ Uat.Autocompleter = Class.create(Autocompleter.Base,
         }
         return html;
     },
-    getLatexTerms: function() {
-        var terms = this.getAddedTerms();
-        var html = '';
-        for ( var i = 0; i < terms.length; i++ ) {
-            if ( i > 0 ) html += ", ";
-            html += terms[i];
-            var externalId = this.getTermInfo( terms[i] ).externalId;
-            if ( externalId ) {
-                html += " ("+externalId+")";
-            }
-        }
-        html = '\\keywords{'+html+'}';
-        return html;
-    },
+
     getClipboardPopup: function(contents, type) {
         // Page Div
         html = '<div>';


### PR DESCRIPTION
We're not going to have people put concepts in their LaTeX files anymore. The reasoning is that we don't think it's particularly valuable to embed these concepts in the output PDF, and while we *could* try to scan concepts from the LaTeX source, there are always going to be cases where manual entry is required, and if we *only* allow manual entry there will be no confusion about which source of information is to be preferred.