### PR TITLE
re-enabling the numeric search

### DIFF
--- a/src/ejp_uat.js
+++ b/src/ejp_uat.js
@@ -533,6 +533,10 @@ Uat.Autocompleter = Class.create(Autocompleter.Base,
                         break;
                     }
                 }
+                if ( !match && termInfo.externalId.match(re) ) {
+                    // TT 26911: Check against external id #
+                    match = true;
+               }
             }
             if ( match ) {
                 choices.push(choice);


### PR DESCRIPTION
This code edit, provided by Joel Plotkin, was made to the local version of the EJPress widget, but not copied into this repo.  It allows a user to input a concept ID number (such as 1528) in order to bring up the label for its concept.  It will bring up all concepts whose ID number contains the number searched for (ie. searching for 3 will being up concept 3, 30, 31, 32, 33, 34, ..., 130, 133, 300, 330, 333, etc...). Future improvement might be to return only the specific matching concept ID.